### PR TITLE
Fix validated birth year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.1.0: 2022-05-31
+* Add dev package requirements
+* Add more test cases
+* Fix bug with incorrect birth years
+* Refactor code to make use of trait
+
 ### 1.0.1: 2020-10-04
 * Change package minimal-stability
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     },
     "prefer-stable": true,
     "require-dev": {
-        "pestphp/pest": "^1.18"
+        "pestphp/pest": "^1.18",
+        "spatie/ray": "^1.34"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "slashplus/identity",
     "description": "Verify the age of a person using the german id card, german passport or german residence permission (eAT).",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/src/Traits/HandlesDates.php
+++ b/src/Traits/HandlesDates.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Slashplus\Identity\Traits;
+
+trait HandlesDates
+{
+    /**
+     * Create datetime from a short format 'ymd'
+     *
+     * IMPORTANT INFORMATION: it is absolutely expected that actual years can NOT be determined precisely by only
+     * providing the "short" year (schema 'y'; i.e. '39': miht be 1939 or 2039). Therefore note, that this method
+     * makes use of "DateTime::createFromFormat) which handles it likes that:
+     * Quote "[...] y => A two digit representation of a year (which is assumed to be in the range 1970-2069, inclusive)
+     * [...]" see: https://www.php.net/manual/en/datetime.createfromformat.php (2022-31-05)
+     *
+     * @param string $year two digit representation of a year
+     * @param string $month two digit representation of a month
+     * @param string $day two digit representation of a day
+     * @param string|null $timeZone string representation of a timezone
+     * @return \DateTime|false
+     */
+    public function createDateFromShortFormat(string $year, string $month, string $day, ?string $timeZone = 'GMT+2') {
+        $timeZone = is_string($timeZone) ? new \DateTimeZone($timeZone) : null;
+        return \DateTime::createFromFormat("ymd H:i:s", "{$year}{$month}{$day} 00:00:00", $timeZone);
+    }
+
+    /**
+     * Create a plausible date as DateTime object from format 'ymd'
+     *
+     * "Plausible" DateTime because the year of a 'ymd' string is not precisely defined. Therefore a i.e. 390710
+     * could technically be a year of ../1839/1939/2039/..
+     * A plausible date in the context of an ID check, is related to a plausible birth date that is likely
+     * to be correct by taking the following into account
+     * - the lifespan of a human is likely to be around a max of 100yrs (although might be longer, we delimit to 99)
+     * - the birth year can not be in the future
+     *
+     * @param string $dateString in format 'ymd'
+     * @param string|null $timeZone
+     * @return \DateTime|false
+     */
+    protected function plausiblePastDateTime(\DateTime $date, ?string $timeZone = 'GMT+2') {
+        $timeZone = is_string($timeZone) ? new \DateTimeZone($timeZone) : null;
+        $currentDate = new \DateTime('now', $timeZone);
+
+        // considering a human >= 100yrs is not able to proceed
+        if ((int)$date->format('Y') > (int) $currentDate->format('Y')) {
+            // careful! only do with years, months might be critical because of leap years...
+            return $date->sub(\DateInterval::createFromDateString('100 year'));
+        }
+
+        return $date;
+    }
+}

--- a/src/Validation/IdCardValidation/Validator.php
+++ b/src/Validation/IdCardValidation/Validator.php
@@ -15,6 +15,8 @@ use Slashplus\Identity\Validation\ValidatorFactory;
  */
 class Validator implements ValidatorContract
 {
+    use \Slashplus\Identity\Traits\HandlesDates;
+
     /**
      * @var \Illuminate\Validation\Validator
      */
@@ -249,7 +251,13 @@ class Validator implements ValidatorContract
      */
     public function validatedBirthDate(?string $timezone = 'GMT+2')
     {
-        return $this->validatedDate('birth', $timezone);
+        $date = $this->validatedDate('birth', $timezone);
+
+        if($date !== false) {
+            return $this->plausiblePastDateTime($date, $timezone);
+        }
+
+        return $date;
     }
 
     /**
@@ -297,8 +305,7 @@ class Validator implements ValidatorContract
             && count(array_intersect_key($valid[$type], array_flip(['year', 'month', 'day']))) === 3
         ) {
             $arr = $valid[$type];
-            $timezone = is_string($timezone) ? new \DateTimeZone($timezone) : null;
-            return \DateTime::createFromFormat('ymd H:i:s', "{$arr['year']}{$arr['month']}{$arr['day']} 00:00:00", $timezone);
+            return $this->createDateFromShortFormat($arr['year'], $arr['month'], $arr['day'], $timezone);
         }
 
         return false;

--- a/src/Validation/PassportValidation/Validator.php
+++ b/src/Validation/PassportValidation/Validator.php
@@ -16,6 +16,8 @@ use Slashplus\Identity\Validation\ValidatorFactory;
  */
 class Validator implements ValidatorContract
 {
+    use \Slashplus\Identity\Traits\HandlesDates;
+
     /**
      * @var \Illuminate\Validation\Validator
      */
@@ -252,7 +254,13 @@ class Validator implements ValidatorContract
      */
     public function validatedBirthDate(?string $timezone = 'GMT+2')
     {
-        return $this->validatedDate('birth', $timezone);
+        $date = $this->validatedDate('birth', $timezone);
+
+        if($date !== false) {
+            return $this->plausiblePastDateTime($date, $timezone);
+        }
+
+        return $date;
     }
 
     /**
@@ -300,8 +308,7 @@ class Validator implements ValidatorContract
             && count(array_intersect_key($valid[$type], array_flip(['year', 'month', 'day']))) === 3
         ) {
             $arr = $valid[$type];
-            $timezone = is_string($timezone) ? new \DateTimeZone($timezone) : null;
-            return \DateTime::createFromFormat('ymd H:i:s', "{$arr['year']}{$arr['month']}{$arr['day']} 00:00:00", $timezone);
+            return $this->createDateFromShortFormat($arr['year'], $arr['month'], $arr['day'], $timezone);
         }
 
         return false;

--- a/src/Validation/ResidenceValidation/Validator.php
+++ b/src/Validation/ResidenceValidation/Validator.php
@@ -16,6 +16,8 @@ use Slashplus\Identity\Validation\ValidatorFactory;
  */
 class Validator implements ValidatorContract
 {
+    use \Slashplus\Identity\Traits\HandlesDates;
+
     /**
      * @var \Illuminate\Validation\Validator
      */
@@ -252,7 +254,13 @@ class Validator implements ValidatorContract
      */
     public function validatedBirthDate(?string $timezone = 'GMT+2')
     {
-        return $this->validatedDate('birth', $timezone);
+        $date = $this->validatedDate('birth', $timezone);
+
+        if($date !== false) {
+            return $this->plausiblePastDateTime($date, $timezone);
+        }
+
+        return $date;
     }
 
     /**
@@ -300,8 +308,7 @@ class Validator implements ValidatorContract
             && count(array_intersect_key($valid[$type], array_flip(['year', 'month', 'day']))) === 3
         ) {
             $arr = $valid[$type];
-            $timezone = is_string($timezone) ? new \DateTimeZone($timezone) : null;
-            return \DateTime::createFromFormat('ymd H:i:s', "{$arr['year']}{$arr['month']}{$arr['day']} 00:00:00", $timezone);
+            return $this->createDateFromShortFormat($arr['year'], $arr['month'], $arr['day'], $timezone);
         }
 
         return false;

--- a/tests/HandlesDatesTest.php
+++ b/tests/HandlesDatesTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Slashplus\Identity\Tests;
+
+use Illuminate\Support\Str;
+use Slashplus\Identity\Traits\HandlesDates;
+
+uses(HandlesDates::class);
+
+it('creates datetime with correct years from correctly', function($year, $parameters, $expectation) {
+    $dateTime = $this->createDateFromShortFormat($year, ...array_values($parameters));
+    expect($dateTime)->toBeInstanceOf(\DateTime::class);
+    expect($dateTime->format('Y-m-d'))->toBe($expectation);
+})->with(
+    function () {
+        for ($i = 0; $i <= 99; $i++) {
+            $shortYear = str_pad((int)$i,2,"0", STR_PAD_LEFT);
+
+            // "y => A two digit representation of a year (which is assumed to be in the range 1970-2069, inclusive)"
+            // see: https://www.php.net/manual/de/datetime.createfromformat.php
+            $expectedYear = (int)$shortYear >= 70 ? "19{$shortYear}": "20{$shortYear}";
+            yield [$shortYear, ['month' => '01', 'day' => '20', 'timezone' => 'GMT+2', 'format' => 'ymd'], "{$expectedYear}-01-20"];
+        }
+    }
+);
+
+it('modifies created datetime to be plausible in the past', function($year, $parameters, $expectation) {
+    $dateTime = $this->createDateFromShortFormat($year, ...array_values($parameters));
+    $this->plausiblePastDateTime($dateTime, $parameters['timezone']);
+    expect($dateTime->format('Y-m-d'))->toBe($expectation);
+})->with(
+    function () {
+        $timeZone = 'GMT+2';
+        $currentYear = (int)(new \DateTime('now', new \DateTimeZone($timeZone)))->format('Y');
+        $futureCentury = $currentYear + 100;
+        for ($i = (int)$currentYear; $i <= $futureCentury; $i++) {
+            $shortYear = Str::substr((string)$i, 2,2);
+            $expectedYear = $i <= $currentYear ? $i : $i - 100;
+
+            yield [$shortYear, ['month' => '01', 'day' => '01', 'timezone' => $timeZone, 'format' => 'ymd'], "{$expectedYear}-01-01"];
+        }
+    }
+);

--- a/tests/IdCardValidatorTest.php
+++ b/tests/IdCardValidatorTest.php
@@ -88,4 +88,10 @@ it('returns the correct birthdate', function($data, $expectation) {
     [['serial' => '3491039407', 'birth' => '9603080', 'expire' => '4707145', 'nationality' => 'D', 'checksum' => '8'], '1996-03-08'],
     [['serial' => '1087601249', 'birth' => '9604249', 'expire' => '4612241', 'nationality' => 'D', 'checksum' => '2'], '1996-04-24'],
     [['serial' => '9620118966', 'birth' => '9607170', 'expire' => '4701110', 'nationality' => 'D', 'checksum' => '6'], '1996-07-17'],
+    [['serial' => '1610772259', 'birth' => '3907100', 'expire' => '4712233', 'nationality' => 'D', 'checksum' => '6'], '1939-07-10'],
+    [['serial' => '3105880104', 'birth' => '6704148', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '4'], '1967-04-14'],
+    [['serial' => '3105880104', 'birth' => '2105312', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '2'], '2021-05-31'],
+    [['serial' => '3105880104', 'birth' => '2205315', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '2'], '2022-05-31'],
+    [['serial' => '3105880104', 'birth' => '0201221', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '8'], '2002-01-22'],
+    [['serial' => '3105880104', 'birth' => '1602294', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '6'], '2016-02-29'],
 ]);

--- a/tests/PassportValidatorTest.php
+++ b/tests/PassportValidatorTest.php
@@ -101,4 +101,10 @@ it('returns the correct birthdate', function($data, $expectation) {
     [['serial' => '3491039407', 'birth' => '9603080', 'gender' => 'F', 'expire' => '4707145', 'nationality' => 'D', 'checksum' => '8'], '1996-03-08'],
     [['serial' => '1087601249', 'birth' => '9604249', 'gender' => 'F', 'expire' => '4612241', 'nationality' => 'D', 'checksum' => '2'], '1996-04-24'],
     [['serial' => '9620118966', 'birth' => '9607170', 'gender' => 'F', 'expire' => '4701110', 'nationality' => 'D', 'checksum' => '6'], '1996-07-17'],
+    [['serial' => '1610772259', 'birth' => '3907100', 'gender' => 'F', 'expire' => '4712233', 'nationality' => 'D', 'checksum' => '6'], '1939-07-10'],
+    [['serial' => '3105880104', 'birth' => '6704148', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '4'], '1967-04-14'],
+    [['serial' => '3105880104', 'birth' => '2105312', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '2'], '2021-05-31'],
+    [['serial' => '3105880104', 'birth' => '2205315', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '2'], '2022-05-31'],
+    [['serial' => '3105880104', 'birth' => '0201221', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '8'], '2002-01-22'],
+    [['serial' => '3105880104', 'birth' => '1602294', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'D', 'checksum' => '6'], '2016-02-29'],
 ]);

--- a/tests/ResidenceValidatorTest.php
+++ b/tests/ResidenceValidatorTest.php
@@ -95,4 +95,10 @@ it('returns the correct birthdate', function($data, $expectation) {
     [['serial' => '3491039407', 'birth' => '9603080', 'gender' => 'F', 'expire' => '4707145', 'nationality' => 'TUR', 'checksum' => '8'], '1996-03-08'],
     [['serial' => '1087601249', 'birth' => '9604249', 'gender' => 'F', 'expire' => '4612241', 'nationality' => 'TUR', 'checksum' => '2'], '1996-04-24'],
     [['serial' => '9620118966', 'birth' => '9607170', 'gender' => 'F', 'expire' => '4701110', 'nationality' => 'TUR', 'checksum' => '6'], '1996-07-17'],
+    [['serial' => '1610772259', 'birth' => '3907100', 'gender' => 'F', 'expire' => '4712233', 'nationality' => 'TUR', 'checksum' => '6'], '1939-07-10'],
+    [['serial' => '3105880104', 'birth' => '6704148', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'TUR', 'checksum' => '4'], '1967-04-14'],
+    [['serial' => '3105880104', 'birth' => '2105312', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'TUR', 'checksum' => '2'], '2021-05-31'],
+    [['serial' => '3105880104', 'birth' => '2205315', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'TUR', 'checksum' => '2'], '2022-05-31'],
+    [['serial' => '3105880104', 'birth' => '0201221', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'TUR', 'checksum' => '8'], '2002-01-22'],
+    [['serial' => '3105880104', 'birth' => '1602294', 'gender' => 'F', 'expire' => '4706230', 'nationality' => 'TUR', 'checksum' => '6'], '2016-02-29'],
 ]);


### PR DESCRIPTION
Although it is expected that actual years can NOT be determined precisely by only providing the "short" year (schema 'y'; i.e. '39': might be 1939 or 2039) it also was the reason for misleading results in the context of birth date validation. 

This PR fixes this behavior by adding logic for expecting realistic birth dates. Therefore some refactorings have been made, and more test cases were added.

## Implemenation-reason for the incorrect results with birth date validation
The implementation used `\DateTime::createFromFormat`. This function determines the full year of a 2-digit year representation by a fixed year range. Therefore 2-digit representations like i.e. 50 (realistic case: a person with birth year of 1950) were interpreted incorrectly.

Quote: "[...] y => A two digit representation of a year (which is assumed to be in the range 1970-2069, inclusive) [...]" see: https://www.php.net/manual/en/datetime.createfromformat.php (2022-31-05)